### PR TITLE
外部のAPサーバにデプロイできるように起動処理を修正

### DIFF
--- a/src/main/java/jp/co/careritz/inmane/InManeApplication.java
+++ b/src/main/java/jp/co/careritz/inmane/InManeApplication.java
@@ -2,11 +2,18 @@ package jp.co.careritz.inmane;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 
 @SpringBootApplication
-public class InManeApplication {
+public class InManeApplication extends SpringBootServletInitializer {
 
 	public static void main(String[] args) {
 		SpringApplication.run(InManeApplication.class, args);
+	}
+
+	@Override
+	public SpringApplicationBuilder configure(SpringApplicationBuilder application){
+		return application.sources(InManeApplication.class);
 	}
 }


### PR DESCRIPTION
現状の起動方式ですとTomcat上にデプロイできません。
web.xmlなどの設定ファイルが作成されていないことが原因のようです。

下記のようにApplicationクラスを書き換えると、起動時に設定ファイルを自動生成してくれてTomcatにデプロイできるようになります。